### PR TITLE
[Enterprise Bot][TypeScript] Update Middlewares

### DIFF
--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/dialogs/main/mainDialog.ts
@@ -44,14 +44,15 @@ export class MainDialog extends RouterDialog {
 
     protected async route(dc: DialogContext): Promise<void> {
         // Check dispatch result
-        const dispatchResult = await this._services.dispatchRecognizer.recognize(dc.context);
+        const dispatchResult = await this._services.dispatchRecognizer.recognizeTurn(dc.context, true);
         const topIntent = LuisRecognizer.topIntent(dispatchResult);
 
         if (topIntent === 'l_general') {
             // If dispatch result is general luis model
-            const luisService = this._services.luisServices.get(process.env.LUIS_GENERAL || '');
-            if (!luisService) { return Promise.reject(new Error('The specified LUIS Model could not be found in your Bot Services configuration.')); } else {
-                const luisResult = await luisService.recognize(dc.context);
+            const luisService = this._services.luisServices.get(process.env.LUIS_GENERAL || "");
+            if (!luisService) { return Promise.reject(new Error("The specified LUIS Model could not be found in your Bot Services configuration.")); }
+            else{
+                const luisResult = await luisService.recognizeTurn(dc.context, true);
                 const generalIntent = LuisRecognizer.topIntent(luisResult);
 
                 // switch on general intents

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/index.ts
@@ -71,6 +71,7 @@ const ADAPTER: BotFrameworkAdapter = new BotFrameworkAdapter({
     appPassword: ENDPOINT_CONFIG.appPassword || process.env.microsoftAppPassword
 });
 
+import { TelemetryLoggerMiddleware } from "./middleware/telemetry/telemetryLoggerMiddleware";
 // Get AppInsights configuration by service name
 const APPINSIGHTS_CONFIGURATION: string = process.env.APPINSIGHTS_NAME || '';
 const APPINSIGHTS_CONFIG: IAppInsightsService = <IAppInsightsService> BOT_CONFIG.findServiceByNameOrId(APPINSIGHTS_CONFIGURATION);
@@ -81,6 +82,10 @@ if (!APPINSIGHTS_CONFIG) {
 const TELEMETRY_CLIENT: TelemetryClient = new TelemetryClient(APPINSIGHTS_CONFIG.instrumentationKey);
 
 ADAPTER.onTurnError = async (turnContext: TurnContext, error: Error): Promise<void> => {
+let appInsightsLogger = new TelemetryLoggerMiddleware( TELEMETRY_CLIENT, true,  true);
+ADAPTER.use(appInsightsLogger);
+
+
     // CAUTION:  The sample simply logs the error to the console.
     console.error(error);
     // For production bots, use AppInsights or similar telemetry system.

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/contentModeratorMiddleware.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/contentModeratorMiddleware.ts
@@ -17,10 +17,20 @@ export class ContentModeratorMiddleware implements Middleware {
     public static readonly ServiceName: string = 'ContentModerator';
 
     /**
+     *Key for Text Moderator result in Bot Context dictionary.
+     */
+    public static readonly TextModeratorResultKey: string = "TextModeratorResult";
+    /**
+     * Content Moderator service key.
+     */
+    public static readonly subscriptionKey: string;
+     /**
+     * Content Moderator service region.
+     */
+    private static readonly region: string;
+    /**
      * Key for Text Moderator result in Bot Context dictionary.
      */
-    public static readonly TextModeratorResultKey: string = 'TextModeratorResult';
-
     private readonly _cmClient: ContentModeratorClient;
 
     /**
@@ -34,11 +44,9 @@ export class ContentModeratorMiddleware implements Middleware {
     }
 
     public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
-        if (context === null) {
-            throw new Error('context is null');
-        }
-
+        
         if (context.activity.type === ActivityTypes.Message) {
+
             const content = new Readable();
             content.push(context.activity.text);
             content.push(null);

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/luisTelemetryConstants.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/luisTelemetryConstants.ts
@@ -5,12 +5,14 @@
  * The Application Insights property names that we're logging.
  */
 export class LuisTelemetryConstants {
-    public static readonly IntentPrefix: string = 'LuisIntent';  // Application Insights Custom Event name (with Intent)
-    public static readonly IntentProperty: string = 'Intent';
-    public static readonly IntentScoreProperty: string = 'IntentScore';
-    public static readonly ConversationIdProperty: string = 'ConversationId';
-    public static readonly QuestionProperty: string = 'Question';
-    public static readonly ActivityIdProperty: string = 'ActivityId';
-    public static readonly SentimentLabelProperty: string = 'SentimentLabel';
-    public static readonly SentimentScoreProperty: string = 'SentimentScore';
+    public static readonly ApplicationId: string = "applicationId";
+    public static readonly IntentPrefix: string = "luisIntent";  // Application Insights Custom Event name (with Intent)
+    public static readonly IntentProperty: string = "intent";
+    public static readonly IntentScoreProperty: string = "intentScore";
+    public static readonly ConversationIdProperty: string = "conversationId";
+    public static readonly QuestionProperty: string = "question";
+    public static readonly ActivityIdProperty: string = "activityId";
+    public static readonly SentimentLabelProperty: string = "sentimentLabel";
+    public static readonly SentimentScoreProperty: string = "sentimentScore";
+    public static readonly DialogId: string = "dialogId";
 }

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/qnaTelemetryConstants.ts
@@ -5,11 +5,14 @@
  * The Application Insights property names that we're logging.
  */
 export class QnATelemetryConstants {
-    public static readonly ActivityIdProperty: string = 'ActivityId';
-    public static readonly UsernameProperty: string = 'Username';
-    public static readonly ConversationIdProperty: string = 'ConversationId';
-    public static readonly OriginalQuestionProperty: string = 'OriginalQuestion';
-    public static readonly QuestionProperty: string = 'Question';
-    public static readonly AnswerProperty: string = 'Answer';
-    public static readonly ScoreProperty: string = 'Score';
+    public static readonly KnowledgeBaseIdProperty: string = "knowledgeBaseId";
+    public static readonly ActivityIdProperty: string = "activityId";
+    public static readonly AnswerProperty: string = "answer";
+    public static readonly ArticleFoundProperty: string = "articleFound";
+    public static readonly ChannelIdProperty: string = "channelId";
+    public static readonly ConversationIdProperty: string = "conversationId";
+    public static readonly OriginalQuestionProperty: string = "originalQuestion";
+    public static readonly QuestionProperty: string = "question";
+    public static readonly ScoreProperty: string = "score";
+    public static readonly UsernameProperty: string = "username";
 }

--- a/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryConstants.ts
+++ b/templates/Enterprise-Template/src/typescript/enterprise-bot/src/middleware/telemetry/telemetryConstants.ts
@@ -2,14 +2,16 @@
 // Licensed under the MIT License
 
 export class TelemetryConstants {
-    public static readonly ActivityIDProperty: string = 'ActivityId';
-    public static readonly ChannelProperty: string = 'Channel';
-    public static readonly FromIdProperty: string = 'FromId';
-    public static readonly FromNameProperty: string = 'FromName';
-    public static readonly RecipientIdProperty: string = 'RecipientId';
-    public static readonly RecipientNameProperty: string = 'RecipientName';
-    public static readonly ConversationIdProperty: string = 'ConversationId';
-    public static readonly ConversationNameProperty: string = 'ConversationName';
-    public static readonly TextProperty: string = 'Text';
-    public static readonly LocaleProperty: string = 'Locale';
+    public static readonly ActivityIDProperty: string = "activityId";
+    public static readonly ReplyActivityIDProperty: string = "replyActivityId";
+    public static readonly ChannelIdProperty: string = "channelId";
+    public static readonly FromIdProperty: string = "fromId";
+    public static readonly FromNameProperty: string = "fromName";
+    public static readonly RecipientIdProperty: string = "recipientId";
+    public static readonly RecipientNameProperty: string = "recipientName";
+    public static readonly ConversationIdProperty: string = "conversationId";
+    public static readonly ConversationNameProperty: string = "conversationName";
+    public static readonly TextProperty: string = "text";
+    public static readonly LocaleProperty: string = "locale";
+    public static readonly SpeakProperty: string = "speak";
 }

--- a/templates/Enterprise-Template/src/typescript/src/middleware/telemetry/telemetryBotDependencyExtension.ts
+++ b/templates/Enterprise-Template/src/typescript/src/middleware/telemetry/telemetryBotDependencyExtension.ts
@@ -1,0 +1,43 @@
+import { TelemetryClient } from "applicationinsights";
+import { DateTimePrompt } from "botbuilder-dialogs";
+import { start } from "repl";
+import { duration } from "moment";
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License
+   
+   export class TelemetryBotDependencyExtension
+    {
+        public static DependencyType: string = "Bot";
+     
+          public static trackBotDependency<TResult>(telemetryClient: TelemetryClient, action: () => TResult, dependencyName: string, dependencyData: string): TResult {
+          // return action();
+
+           if (dependencyName === null) {
+             throw new Error("Missing parameter, dependencyName is required"); 
+           }
+           var startTime = Date.now();         
+           var success = true;
+
+           try {
+               return action();
+           }
+           catch (Exception) {
+               success = false;
+               throw Exception;
+           }
+           finally {
+               var endTime = Date.now();
+               let duration = endTime - startTime;
+               // Log the dependency into Application Insights
+               telemetryClient.trackDependency({
+                   dependencyTypeName: TelemetryBotDependencyExtension.DependencyType,
+                   name: dependencyName,
+                   data: dependencyData,
+                   success: success,
+                   duration: duration,
+                   resultCode: 0
+               });
+           }
+       }
+    }


### PR DESCRIPTION
## Description

The structure of the middlewares between C# and TypeScript contains a similar information. For this purpose we changed the following things:

- Change the project structure on Typescript. 
- Add telemetryBotDependencyExtension
- The file SetLocaleMiddleware is not necessary on Typescript version
- Update the files inside the telemetry folder
- Update the files index.ts and mainDialog.ts to use the new middlewares

![image](https://user-images.githubusercontent.com/42946572/51350229-64c3bc80-1a86-11e9-93cb-110d637a322b.png)

## Related Issue
Fixes 561

## Testing Steps

1. Open `AI/templates/Enterprise-Template/src/typescript/src/middleware/telemetry` and 
`AI/templates/Enterprise-Template/src/csharp/EnterpriseBotSample/Middleware/Telemetry`.
2. Check the structure between them.

## Checklist
- [X] I have commented my code, particularly in hard-to-understand areas
~- [] I have added or updated the appropriate unit tests~
~- [] I have updated related documentation~

If this contains changes that needs to be replicated between the Enterprise Template <-> Virtual Assistant
~- [ ] A duplicate issue is filed to track future  work.~

If you have updated responses or `.lu` files:
~- [] All languages have been updated~
- [X] You have tested deployment with your new models